### PR TITLE
Update rpm fingerprint to latest key (575B15D1)

### DIFF
--- a/vars/almalinux-10.yml
+++ b/vars/almalinux-10.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:

--- a/vars/almalinux-8.yml
+++ b/vars/almalinux-8.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:

--- a/vars/almalinux-9.yml
+++ b/vars/almalinux-9.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:

--- a/vars/centos-10.yml
+++ b/vars/centos-10.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:

--- a/vars/centos-7.yml
+++ b/vars/centos-7.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:

--- a/vars/centos-8.yml
+++ b/vars/centos-8.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:

--- a/vars/centos-9.yml
+++ b/vars/centos-9.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:

--- a/vars/fedora-41.yml
+++ b/vars/fedora-41.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:

--- a/vars/fedora-42.yml
+++ b/vars/fedora-42.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:

--- a/vars/redhat-7.yml
+++ b/vars/redhat-7.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:

--- a/vars/redhat-8.yml
+++ b/vars/redhat-8.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:

--- a/vars/redhat-9.yml
+++ b/vars/redhat-9.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:

--- a/vars/suse-15.6.yml
+++ b/vars/suse-15.6.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:

--- a/vars/suse.yml
+++ b/vars/suse.yml
@@ -16,7 +16,7 @@
 
 _rpm_key:
   - key: https://linux.teamviewer.com/pubkey/currentkey.asc
-    fingerprint: 8CAE012EBFAC38B17A937CD8C5E224500C1289C0
+    fingerprint: AB2985BDE164897BA46EA69A234FAACB575B15D1
     state: present
 
 _yum_repository:


### PR DESCRIPTION
Before this change role failed with:

    The specified fingerprint, '8CAE012EBFAC38B17A937CD8C5E224500C1289C0', does
    not match the key fingerprint 'AB2985BDE164897BA46EA69A234FAACB575B15D1'

You could double check this with following command:

```
$ curl -s https://linux.teamviewer.com/pubkey/currentkey.asc | gpg --no-default-keyring --no-options --show-keys -
pub   rsa4096 2023-03-24 [SC]
      AB2985BDE164897BA46EA69A234FAACB575B15D1
uid                      TeamViewer Germany GmbH (TeamViewer for Linux, 2023) <support@teamviewer.com>
sub   rsa4096 2023-03-24 [E]
sub   rsa4096 2023-03-24 [S]
```

This has been tested on Fedora 42 (only) and I assume this would fail on any of other systems where the old fingerprint was present.